### PR TITLE
Fixed a bug in function ALSOpenAudioFile() under Windows

### DIFF
--- a/source/libsndfile.pas
+++ b/source/libsndfile.pas
@@ -1058,7 +1058,7 @@ end;
 function ALSOpenAudioFile(const aFilename: string; aMode: cint; var aSFInfo: TSF_INFO): PSNDFILE;
 {$ifdef windows}var s: UNICODESTRING; {$endif}
 begin
-  FillChar(aSFInfo, SizeOf(TSF_INFO), 0);
+  if aMode <> SFM_WRITE then FillChar(aSFInfo, SizeOf(TSF_INFO), 0);
   {$ifdef windows}
   s := UNICODESTRING(aFilename);
   Result := sf_wchar_open(LPCWSTR((s)), aMode, @aSFInfo);


### PR DESCRIPTION
Previously the TSF_INFO parameter was filled with zero at the beginning of the function: it didn't work when user want to open a file in write mode, where s/he must fill the TSF_INFO with the file format. Now, the TSF_INFO parameter is filled with zero only if the mode is different from SFM_WRITE.